### PR TITLE
Decrease error fix for cart

### DIFF
--- a/lib/hooks/useCartStore.ts
+++ b/lib/hooks/useCartStore.ts
@@ -76,7 +76,7 @@ export default function useCartService() {
       const updatedCartItems =
         exist.qty === 1
           ? items.filter((x: OrderItem) => x.slug !== item.slug)
-          : items.map((x) => (item.slug ? { ...exist, qty: exist.qty - 1 } : x))
+          : items.map((x) => (x.slug === item.slug ? { ...exist, qty: exist.qty - 1 } : x))
       const { itemsPrice, shippingPrice, taxPrice, totalPrice } =
         calcPrice(updatedCartItems)
       cartStore.setState({


### PR DESCRIPTION
Fix: Ensure only the intended product quantity is updated in the cart

The issue occurred because the logic was not properly matching the specific item (slug) in the cart to be updated. As a result, the changes applied to all items in the cart.

adding two different product 
![image](https://github.com/user-attachments/assets/f98fe100-462f-4cf7-8895-a83bc0e9d204)
after decreasing count of one product 
![image](https://github.com/user-attachments/assets/d287581a-a3f3-4bc2-a8db-6742edae0eb3)
